### PR TITLE
Misconfig of subnet on tunnel interfaces

### DIFF
--- a/doc_source/fortinet.md
+++ b/doc_source/fortinet.md
@@ -123,7 +123,7 @@ config vpn ipsec phase2-interface
 config system interface
  edit "vpn-44a8938f-0"
   set vdom "root"
-  set ip 169.254.255.2 255.255.255.255 
+  set ip 169.254.255.2 255.255.255.252 
   set allowaccess ping 
   set type tunnel 
 
@@ -318,7 +318,7 @@ config vpn ipsec phase2-interface
 config system interface
  edit "vpn-44a8938f-1"
   set vdom "root"
-  set ip 169.254.255.6 255.255.255.255 
+  set ip 169.254.255.6 255.255.255.252 
   set allowaccess ping 
   set type tunnel 
 


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

Not sure if this is intended, as it's different from the other configurations, but with a /32 on the tunnel interfaces they can never reach the tunnel remote-peer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
